### PR TITLE
Restore inclusion of global.css and remove padding from body

### DIFF
--- a/app/public/global.css
+++ b/app/public/global.css
@@ -7,7 +7,6 @@ html, body {
 body {
     color: #333;
     margin: 0;
-    padding: 8px;
     box-sizing: border-box;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 }

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -6,6 +6,7 @@
 
   <title>Svelte app</title>
 
+  <link rel='stylesheet' href='/global.css'>
   <link rel='stylesheet' href='/build/bundle.css'>
   <link rel='stylesheet' href='/build/public/build/extra.css'>
 


### PR DESCRIPTION
- Restore inclusion of global.css

    This is present in sveltejs/template.

- Remove padding from body

    so the map fills the entire page.